### PR TITLE
reverse forced uppercase titles from white theme

### DIFF
--- a/css/reveal-override.css
+++ b/css/reveal-override.css
@@ -53,7 +53,7 @@ body,
 .reveal h6 {
   font-family: "Cabin", sans-serif;
   font-weight: bold;
-  text-transform: uppercase;
+  text-transform: none;
   text-stroke: 1px black;
   color: white;
   text-shadow:


### PR DESCRIPTION
All caps is ugly, LIKE SHOUTING, and hard to read.
For the cases where we really do want all caps, we can
simply do that in the markdown.  But there are cases
(e.g. "SUSE OpenStack Cloud") where we DEFINITELY DON'T
WANT ALL CAPS, SO DON'T GODDAMN FORCE US INTO IT OK?

;-)
